### PR TITLE
Fix log spam and correct Blood Magic reflection path

### DIFF
--- a/src/main/java/com/otectus/arsnspells/casting/CastingAuthority.java
+++ b/src/main/java/com/otectus/arsnspells/casting/CastingAuthority.java
@@ -56,7 +56,7 @@ public class CastingAuthority {
             
             if (hasCursed) {
                 // Cursed Ring replaces mana cost with Blood Magic LP
-                LOGGER.info("🔴 CURSED RING DETECTED - Using LP instead of mana for {}", player.getName().getString());
+                LOGGER.debug("Cursed Ring detected - Using LP instead of mana for {}", player.getName().getString());
                 return validateCursedRingCost(player, resolver, manaCost);
             }
         } else {
@@ -92,46 +92,45 @@ public class CastingAuthority {
      * @return true if LP was successfully consumed
      */
     private static boolean validateCursedRingCost(Player player, SpellResolver resolver, int manaCost) {
-        LOGGER.info("🔴 validateCursedRingCost called for player: {}, mana cost: {}", 
+        LOGGER.debug("validateCursedRingCost called for player: {}, mana cost: {}",
             player.getName().getString(), manaCost);
-        
+
         // Get the first spell part for tier/rarity info
         AbstractSpellPart spellPart = null;
         if (resolver.spell != null && resolver.spell.recipe != null && !resolver.spell.recipe.isEmpty()) {
             spellPart = resolver.spell.recipe.get(0);
-            LOGGER.info("   Spell part: {}", spellPart.getRegistryName());
+            LOGGER.debug("Spell part: {}", spellPart.getRegistryName());
         } else {
-            LOGGER.warn("   No spell part found in resolver");
+            LOGGER.debug("No spell part found in resolver");
         }
-        
+
         // Calculate LP cost
         int lpCost = SanctifiedLegacyCompat.calculateLPCost(manaCost, spellPart);
-        LOGGER.info("   Calculated LP cost: {} (base mana: {})", lpCost, manaCost);
-        
+        LOGGER.debug("Calculated LP cost: {} (base mana: {})", lpCost, manaCost);
+
         // Determine spell school for Blasphemy multiplier
         String spellSchool = SanctifiedLegacyCompat.determineSpellSchool(spellPart);
-        LOGGER.info("   Detected spell school: {}", spellSchool);
-        
+        LOGGER.debug("Detected spell school: {}", spellSchool);
+
         // Apply Blasphemy multiplier if applicable
         double blasphemyMultiplier = SanctifiedLegacyCompat.getBlasphemyMultiplier(player, spellSchool);
         if (blasphemyMultiplier < 1.0) {
             int originalCost = lpCost;
             lpCost = (int) Math.max(100, Math.round(lpCost * blasphemyMultiplier));
-            LOGGER.info("   Blasphemy multiplier applied: {:.2f} ({} LP -> {} LP)", 
+            LOGGER.debug("Blasphemy multiplier applied: {} ({} LP -> {} LP)",
                 blasphemyMultiplier, originalCost, lpCost);
         }
-        
-        LOGGER.info("   Final LP cost: {}", lpCost);
+
+        LOGGER.debug("Final LP cost: {}", lpCost);
 
         // Check if player has enough LP (don't consume yet - event handlers will do that)
-        LOGGER.info("   Checking LP availability...");
         boolean hasEnough = SanctifiedLegacyCompat.hasEnoughLP(player, lpCost);
 
         if (hasEnough) {
-            LOGGER.info("   ✅ Player has sufficient LP!");
+            LOGGER.debug("Player has sufficient LP");
         } else {
-            LOGGER.warn("   ❌ Insufficient LP!");
-            sendDenialMessage(player, "§cInsufficient Life Points (LP): Need " + lpCost + " LP");
+            LOGGER.debug("Insufficient LP");
+            sendDenialMessage(player, "\u00a7cInsufficient Life Points (LP): Need " + lpCost + " LP");
         }
 
         return hasEnough;

--- a/src/main/java/com/otectus/arsnspells/compat/SanctifiedLegacyCompat.java
+++ b/src/main/java/com/otectus/arsnspells/compat/SanctifiedLegacyCompat.java
@@ -81,7 +81,7 @@ public class SanctifiedLegacyCompat {
     private static void initBloodMagicReflection() {
         try {
             // Try to find Blood Magic's NetworkHelper class
-            bloodMagicNetworkClass = Class.forName("wayoftime.bloodmagic.common.util.helper.NetworkHelper");
+            bloodMagicNetworkClass = Class.forName("wayoftime.bloodmagic.util.helper.NetworkHelper");
             getSoulNetworkMethod = bloodMagicNetworkClass.getMethod("getSoulNetwork", java.util.UUID.class);
 
             // Get SoulNetwork class methods
@@ -170,37 +170,19 @@ public class SanctifiedLegacyCompat {
     private static boolean hasCurio(Player player, String curioId) {
         try {
             ResourceLocation itemId = new ResourceLocation(curioId);
-            
-            LOGGER.info("      Checking for curio: {}", curioId);
-            LOGGER.info("      Target ID: namespace='{}', path='{}'", itemId.getNamespace(), itemId.getPath());
-            
-            // Use Ars Nouveau's CuriosUtil to get all worn items
-            boolean found = CuriosUtil.getAllWornItems(player).map(handler -> {
-                LOGGER.info("      Curio handler found, slots: {}", handler.getSlots());
+
+            return CuriosUtil.getAllWornItems(player).map(handler -> {
                 for (int i = 0; i < handler.getSlots(); i++) {
                     ItemStack stack = handler.getStackInSlot(i);
                     if (!stack.isEmpty()) {
                         ResourceLocation stackId = net.minecraftforge.registries.ForgeRegistries.ITEMS.getKey(stack.getItem());
-                        LOGGER.info("      Slot {}: {}", i, stackId);
-                        LOGGER.info("         Stack ID: namespace='{}', path='{}'", 
-                            stackId != null ? stackId.getNamespace() : "null", 
-                            stackId != null ? stackId.getPath() : "null");
-                        LOGGER.info("         Equals check: {}", stackId != null && stackId.equals(itemId));
-                        LOGGER.info("         Namespace match: {}", stackId != null && stackId.getNamespace().equals(itemId.getNamespace()));
-                        LOGGER.info("         Path match: {}", stackId != null && stackId.getPath().equals(itemId.getPath()));
-                        
                         if (stackId != null && stackId.equals(itemId)) {
-                            LOGGER.info("      ✅ FOUND matching curio at slot {}!", i);
                             return true;
                         }
                     }
                 }
-                LOGGER.info("      ❌ Curio not found in any slot");
                 return false;
             }).orElse(false);
-            
-            LOGGER.info("      Final result: {}", found);
-            return found;
         } catch (Exception e) {
             LOGGER.error("Failed to check for curio {}: {}", curioId, e.getMessage(), e);
             return false;
@@ -378,24 +360,24 @@ public class SanctifiedLegacyCompat {
         if (mode == LPSourceMode.BLOOD_MAGIC_PRIORITY || mode == LPSourceMode.BLOOD_MAGIC_ONLY) {
             if (isBloodMagicAvailable()) {
                 int currentLP = getBloodMagicLP(player);
-                LOGGER.info("💉 Attempting to consume {} LP from {}'s Soul Network (has {} LP)",
+                LOGGER.debug("Attempting to consume {} LP from {}'s Soul Network (has {} LP)",
                     lpCost, player.getName().getString(), currentLP);
 
                 if (currentLP >= lpCost) {
                     boolean success = consumeBloodMagicLP(player, lpCost);
                     if (success) {
-                        LOGGER.info("   ✅ Successfully consumed {} LP from Soul Network", lpCost);
+                        LOGGER.debug("Successfully consumed {} LP from Soul Network", lpCost);
                         return true;
                     }
                 }
 
                 // If Blood Magic only mode and failed, don't fall back to health
                 if (mode == LPSourceMode.BLOOD_MAGIC_ONLY) {
-                    LOGGER.warn("   ❌ Insufficient LP in Soul Network: need {} but only have {}", lpCost, currentLP);
+                    LOGGER.debug("Insufficient LP in Soul Network: need {} but only have {}", lpCost, currentLP);
                     return false;
                 }
 
-                LOGGER.info("   Insufficient Soul Network LP, falling back to health");
+                LOGGER.debug("Insufficient Soul Network LP, falling back to health");
             } else if (mode == LPSourceMode.BLOOD_MAGIC_ONLY) {
                 LOGGER.warn("Blood Magic not available but LP_SOURCE_MODE is BLOOD_MAGIC_ONLY");
                 return false;
@@ -407,12 +389,12 @@ public class SanctifiedLegacyCompat {
         float currentHealth = player.getHealth();
         float maxHealth = player.getMaxHealth();
 
-        LOGGER.info("💉 Attempting to consume {} LP ({} health) from {}'s health",
+        LOGGER.debug("Attempting to consume {} LP ({} health) from {}'s health",
             lpCost, healthCost, player.getName().getString());
-        LOGGER.info("   Current health: {}/{}", currentHealth, maxHealth);
+        LOGGER.debug("Current health: {}/{}", currentHealth, maxHealth);
 
         if (currentHealth <= healthCost + 1.0f) {
-            LOGGER.warn("   ❌ Insufficient health: need {} but only have {} (keeping 1 HP buffer)",
+            LOGGER.debug("Insufficient health: need {} but only have {} (keeping 1 HP buffer)",
                 healthCost, currentHealth);
             return false;
         }
@@ -420,7 +402,7 @@ public class SanctifiedLegacyCompat {
         float newHealth = currentHealth - healthCost;
         player.setHealth(newHealth);
 
-        LOGGER.info("   ✅ Successfully consumed {} LP ({} health) - new health: {}",
+        LOGGER.debug("Successfully consumed {} LP ({} health) - new health: {}",
             lpCost, healthCost, newHealth);
 
         return true;

--- a/src/main/java/com/otectus/arsnspells/events/CursedRingHandler.java
+++ b/src/main/java/com/otectus/arsnspells/events/CursedRingHandler.java
@@ -56,12 +56,12 @@ public class CursedRingHandler {
         }
 
         
-        LOGGER.info("🔴 CURSED RING DETECTED on {} - Spell will use LP instead of mana", 
+        LOGGER.debug("Cursed Ring detected on {} - Spell will use LP instead of mana",
             player.getName().getString());
         
         int manaCost = event.currentCost;
         if (manaCost <= 0) {
-            LOGGER.info("   Zero cost spell - allowing");
+            LOGGER.debug("Zero cost spell - allowing");
             return;
         }
 
@@ -80,10 +80,10 @@ public class CursedRingHandler {
         if (blasphemyMultiplier < 1.0) {
             int originalCost = lpCost;
             lpCost = (int) Math.max(100, Math.round(lpCost * blasphemyMultiplier));
-            LOGGER.info("   Blasphemy discount applied: {} LP -> {} LP", originalCost, lpCost);
+            LOGGER.debug("Blasphemy discount applied: {} LP -> {} LP", originalCost, lpCost);
         }
         
-        LOGGER.info("   Spell will cost {} LP (base mana: {})", lpCost, manaCost);
+        LOGGER.debug("Spell will cost {} LP (base mana: {})", lpCost, manaCost);
         
         // Store the LP cost for consumption in the resolve event
         pendingCosts.put(player.getUUID(), new PendingLPCost(lpCost, System.currentTimeMillis()));
@@ -91,7 +91,7 @@ public class CursedRingHandler {
         // Set mana cost to 0 so Ars Nouveau doesn't consume mana
         event.currentCost = 0;
         
-        LOGGER.info("   Mana cost set to 0 (LP will be consumed on spell resolve)");
+        LOGGER.debug("Mana cost set to 0 (LP will be consumed on spell resolve)");
     }
 
     /**
@@ -164,7 +164,7 @@ public class CursedRingHandler {
             return;
         }
         
-        LOGGER.info("💉 Consuming {} LP from {}'s Soul Network", pending.lpCost, player.getName().getString());
+        LOGGER.debug("Consuming {} LP from {}'s Soul Network", pending.lpCost, player.getName().getString());
         
         // Attempt to consume LP
         boolean success = SanctifiedLegacyCompat.consumeLP(player, pending.lpCost);
@@ -202,7 +202,7 @@ public class CursedRingHandler {
                 }
             }
         } else {
-            LOGGER.info("   ✅ LP consumed successfully - spell will execute");
+            LOGGER.debug("LP consumed successfully - spell will execute");
             pending.consumed = true;
             
             if (AnsConfig.SHOW_LP_COST_MESSAGES.get()) {

--- a/src/main/java/com/otectus/arsnspells/events/IronsLPHandler.java
+++ b/src/main/java/com/otectus/arsnspells/events/IronsLPHandler.java
@@ -69,9 +69,9 @@ public class IronsLPHandler {
         SpellRarity rarity = spell.getRarity(spellLevel);
         int lpCost = SanctifiedLegacyCompat.calculateIronsLPCost(manaCost, spellLevel, rarity.name());
 
-        LOGGER.info("Cursed Ring active for Iron's spell on {}", player.getName().getString());
-        LOGGER.info("Iron's spell: {}, Level: {}, Rarity: {}", event.getSpellId(), spellLevel, rarity.name());
-        LOGGER.info("Calculated LP cost: {} (base mana: {})", lpCost, manaCost);
+        LOGGER.debug("Cursed Ring active for Iron's spell on {}", player.getName().getString());
+        LOGGER.debug("Iron's spell: {}, Level: {}, Rarity: {}", event.getSpellId(), spellLevel, rarity.name());
+        LOGGER.debug("Calculated LP cost: {} (base mana: {})", lpCost, manaCost);
 
         boolean hasEnough = SanctifiedLegacyCompat.hasEnoughLP(player, lpCost);
         if (!hasEnough) {
@@ -170,7 +170,7 @@ public class IronsLPHandler {
                 true
             );
         }
-        LOGGER.info("Iron's spell cast - {} LP consumed", pending.lpCost);
+        LOGGER.debug("Iron's spell cast - {} LP consumed", pending.lpCost);
     }
 
     /**

--- a/src/main/java/com/otectus/arsnspells/events/LPDeathPrevention.java
+++ b/src/main/java/com/otectus/arsnspells/events/LPDeathPrevention.java
@@ -26,11 +26,11 @@ import java.util.UUID;
 @Mod.EventBusSubscriber(modid = "ars_n_spells")
 public class LPDeathPrevention {
     private static final Logger LOGGER = LoggerFactory.getLogger(LPDeathPrevention.class);
-    
+
     // Track recent spell casts to detect LP-related damage
     private static final Map<UUID, Long> recentSpellCasts = new HashMap<>();
     private static final long DAMAGE_WINDOW_MS = 2000; // 2 second window after spell cast (increased for multiple death events)
-    
+
     /**
      * Mark when a player casts a spell with Cursed Ring.
      */
@@ -38,10 +38,10 @@ public class LPDeathPrevention {
         if (player != null) {
             long timestamp = System.currentTimeMillis();
             recentSpellCasts.put(player.getUUID(), timestamp);
-            LOGGER.info("🔖 Marked spell cast for {} at timestamp {}", player.getName().getString(), timestamp);
+            LOGGER.debug("Marked spell cast for {} at timestamp {}", player.getName().getString(), timestamp);
         }
     }
-    
+
     /**
      * Intercept damage events to prevent death from insufficient LP.
      * This runs at HIGHEST priority to catch damage before it's applied.
@@ -51,72 +51,71 @@ public class LPDeathPrevention {
         if (!(event.getEntity() instanceof ServerPlayer player)) {
             return;
         }
-        
-        // Log ALL damage to this player for debugging
-        LOGGER.info("🩸 Player damage event: {} damage from {}", 
+
+        LOGGER.debug("Player damage event: {} damage from {}",
             event.getAmount(), event.getSource().getMsgId());
-        
+
         // Only intercept if death penalty is disabled
         if (AnsConfig.DEATH_ON_INSUFFICIENT_LP.get()) {
-            LOGGER.info("   Death penalty enabled - allowing damage");
+            LOGGER.debug("Death penalty enabled - allowing damage");
             return; // Death penalty enabled - allow death
         }
-        
+
         // Check if wearing Cursed Ring
         if (!SanctifiedLegacyCompat.isWearingCursedRing(player)) {
-            LOGGER.info("   Not wearing Cursed Ring - ignoring");
+            LOGGER.debug("Not wearing Cursed Ring - ignoring");
             return;
         }
-        
-        LOGGER.info("   Wearing Cursed Ring - checking if LP-related damage");
-        
+
+        LOGGER.debug("Wearing Cursed Ring - checking if LP-related damage");
+
         // Check if this damage is from LP penalty
         DamageSource source = event.getSource();
         String damageType = source.getMsgId();
-        
-        LOGGER.info("   Damage type: {}", damageType);
-        
+
+        LOGGER.debug("Damage type: {}", damageType);
+
         // Check for LP-related damage types
         // Blood Magic uses "sacrifice" damage type for LP costs
         // Also check for magic damage as a fallback
-        if (!damageType.contains("magic") && 
-            !damageType.contains("indirectMagic") && 
+        if (!damageType.contains("magic") &&
+            !damageType.contains("indirectMagic") &&
             !damageType.contains("sacrifice")) {
-            LOGGER.info("   Not LP-related damage (not magic or sacrifice) - ignoring");
+            LOGGER.debug("Not LP-related damage (not magic or sacrifice) - ignoring");
             return;
         }
-        
-        LOGGER.info("   ✅ LP-related damage detected (type: {})", damageType);
-        
+
+        LOGGER.debug("LP-related damage detected (type: {})", damageType);
+
         // Check if this is within the spell cast window
         Long lastCast = recentSpellCasts.get(player.getUUID());
         if (lastCast == null) {
-            LOGGER.info("   No recent spell cast - ignoring");
+            LOGGER.debug("No recent spell cast - ignoring");
             return;
         }
-        
+
         long timeSinceCast = System.currentTimeMillis() - lastCast;
-        LOGGER.info("   Time since spell cast: {}ms", timeSinceCast);
-        
+        LOGGER.debug("Time since spell cast: {}ms", timeSinceCast);
+
         if (timeSinceCast > DAMAGE_WINDOW_MS) {
-            LOGGER.info("   Outside damage window - ignoring");
+            LOGGER.debug("Outside damage window - ignoring");
             return; // Too long ago - not related to spell cast
         }
-        
+
         float damage = event.getAmount();
         float playerHealth = player.getHealth();
 
-        LOGGER.info("🛡️ LP damage intercepted: {} damage, player health: {}", damage, playerHealth);
+        LOGGER.debug("LP damage intercepted: {} damage, player health: {}", damage, playerHealth);
 
         // CANCEL ALL sacrifice/magic damage from native Cursed Ring
         // Our custom LP consumption already happened, so any additional damage is from
         // Enigmatic Legacy's native Cursed Ring system and should be completely blocked
-        LOGGER.info("   ❌ Canceling native Cursed Ring damage (our custom LP already consumed)");
+        LOGGER.debug("Canceling native Cursed Ring damage (our custom LP already consumed)");
         event.setCanceled(true);
 
-        LOGGER.info("   Damage event cancelled - player protected from native ring effects");
+        LOGGER.debug("Damage event cancelled - player protected from native ring effects");
     }
-    
+
     /**
      * Intercept death events to prevent LP-related deaths when death penalty is disabled.
      * This is the FINAL safety net - if damage interception fails, we prevent death here.
@@ -126,78 +125,75 @@ public class LPDeathPrevention {
         if (!(event.getEntity() instanceof ServerPlayer player)) {
             return;
         }
-        
-        LOGGER.info("💀 Player death event for {}", player.getName().getString());
-        LOGGER.info("   Death source: {}", event.getSource().getMsgId());
-        
+
+        LOGGER.debug("Player death event for {}", player.getName().getString());
+        LOGGER.debug("Death source: {}", event.getSource().getMsgId());
+
         // Only intercept if death penalty is disabled
         if (AnsConfig.DEATH_ON_INSUFFICIENT_LP.get()) {
-            LOGGER.info("   Death penalty enabled - allowing death");
+            LOGGER.debug("Death penalty enabled - allowing death");
             return;
         }
-        
+
         // Check if wearing Cursed Ring
         if (!SanctifiedLegacyCompat.isWearingCursedRing(player)) {
-            LOGGER.info("   Not wearing Cursed Ring - allowing death");
+            LOGGER.debug("Not wearing Cursed Ring - allowing death");
             return;
         }
-        
-        LOGGER.info("   Wearing Cursed Ring - checking if LP-related death");
-        
+
+        LOGGER.debug("Wearing Cursed Ring - checking if LP-related death");
+
         // Check if this death is from sacrifice (LP cost)
         String deathType = event.getSource().getMsgId();
         if (!deathType.contains("sacrifice") && !deathType.contains("magic")) {
-            LOGGER.info("   Not LP-related death (type: {}) - allowing", deathType);
+            LOGGER.debug("Not LP-related death (type: {}) - allowing", deathType);
             return;
         }
-        
+
         // Check if this is within the spell cast window
         Long lastCast = recentSpellCasts.get(player.getUUID());
         long currentTime = System.currentTimeMillis();
-        
-        LOGGER.info("   Checking spell cast marker:");
-        LOGGER.info("      Current time: {}", currentTime);
-        LOGGER.info("      Last cast time: {}", lastCast);
-        LOGGER.info("      Marker exists: {}", lastCast != null);
-        
+
+        LOGGER.debug("Checking spell cast marker: currentTime={}, lastCast={}, exists={}",
+            currentTime, lastCast, lastCast != null);
+
         if (lastCast == null) {
-            LOGGER.warn("   ❌ No recent spell cast marker found - allowing death");
-            LOGGER.warn("      This means markSpellCast() was never called or marker was cleared");
+            LOGGER.debug("No recent spell cast marker found - allowing death");
             return;
         }
-        
+
         long timeSinceCast = currentTime - lastCast;
-        LOGGER.info("      Time since cast: {}ms (window: {}ms)", timeSinceCast, DAMAGE_WINDOW_MS);
-        
+        LOGGER.debug("Time since cast: {}ms (window: {}ms)", timeSinceCast, DAMAGE_WINDOW_MS);
+
         if (timeSinceCast > DAMAGE_WINDOW_MS) {
-            LOGGER.warn("   ❌ Outside spell cast window ({}ms > {}ms) - allowing death", timeSinceCast, DAMAGE_WINDOW_MS);
+            LOGGER.debug("Outside spell cast window ({}ms > {}ms) - allowing death", timeSinceCast, DAMAGE_WINDOW_MS);
             return;
         }
-        
-        LOGGER.info("   ✅ Within spell cast window - will prevent death");
-        
+
+        LOGGER.debug("Within spell cast window - will prevent death");
+
         // This is an LP-related death from insufficient LP - PREVENT IT
-        LOGGER.warn("🛡️ PREVENTING LP-RELATED DEATH (safe mode active)");
+        LOGGER.warn("Preventing LP-related death for {} (safe mode active)", player.getName().getString());
         event.setCanceled(true);
-        
+
         // Set player health to 1 heart to prevent death
         player.setHealth(2.0f);
-        
+
         // Show message (only once)
         if (AnsConfig.SHOW_LP_COST_MESSAGES.get()) {
             player.displayClientMessage(
-                Component.literal("§cInsufficient LP - Spell Cancelled"), 
+                Component.literal("\u00a7cInsufficient LP - Spell Cancelled"),
                 true
             );
         }
-        
-        LOGGER.info("   Death cancelled - player health set to 2.0 (1 heart)");
-        
+
+        LOGGER.debug("Death cancelled - player health set to 2.0 (1 heart)");
+
         // DON'T remove the spell cast marker yet!
         // Blood Magic fires multiple death events, so we need to keep the marker
         // to intercept all of them. It will be cleaned up by the tick handler.
     }
-    
+
     /**
      * Clean up old spell cast timestamps.
      */
@@ -206,7 +202,7 @@ public class LPDeathPrevention {
         if (event.phase != net.minecraftforge.event.TickEvent.Phase.END) {
             return;
         }
-        
+
         if (event.player.tickCount % 100 == 0) { // Every 5 seconds
             long now = System.currentTimeMillis();
             recentSpellCasts.entrySet().removeIf(entry -> now - entry.getValue() > DAMAGE_WINDOW_MS);


### PR DESCRIPTION
## Summary
- **Eliminate hasCurio() log spam**: Removed per-slot INFO logging that produced 411+ lines in a 3-minute session. The method now silently checks curio slots, logging only on errors.
- **Downgrade runtime logging to DEBUG**: All per-event and per-tick INFO logging across 5 files (CursedRingHandler, IronsLPHandler, LPDeathPrevention, CastingAuthority, SanctifiedLegacyCompat) now uses DEBUG level, keeping logs clean during normal gameplay.
- **Fix Blood Magic reflection path**: Changed `wayoftime.bloodmagic.common.util.helper.NetworkHelper` to `wayoftime.bloodmagic.util.helper.NetworkHelper`, matching the actual Blood Magic 1.20.1 v3.3.5 jar structure. This resolves the "Blood Magic classes not found" warning that appeared even with Blood Magic installed.

## Test plan
- [ ] Launch modpack and verify no Ars 'n' Spells INFO spam in `latest.log` during normal gameplay
- [ ] Equip Cursed Ring and cast Ars Nouveau spells — verify LP consumption works and only DEBUG-level messages appear
- [ ] Equip Cursed Ring and cast Iron's Spellbooks spells — verify LP consumption works
- [ ] Verify Blood Magic Soul Network integration connects without warnings at startup
- [ ] Test with `debug_mode=true` in config to confirm debug logging still works when explicitly enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)