### PR TITLE
Fix spell cost enforcement, aura system, scroll costs, and hybrid mana

### DIFF
--- a/src/main/java/com/otectus/arsnspells/ArsNSpells.java
+++ b/src/main/java/com/otectus/arsnspells/ArsNSpells.java
@@ -1,5 +1,7 @@
 package com.otectus.arsnspells;
 
+import com.otectus.arsnspells.aura.AuraCapabilityProvider;
+import com.otectus.arsnspells.aura.IAuraCapability;
 import com.otectus.arsnspells.bridge.BridgeManager;
 import com.otectus.arsnspells.compat.SanctifiedLegacyCompat;
 import com.otectus.arsnspells.config.AnsConfig;
@@ -52,7 +54,9 @@ public class ArsNSpells {
         MinecraftForge.EVENT_BUS.register(EquipmentHandler.class);
         MinecraftForge.EVENT_BUS.register(CurioDiscountHandler.class);
         MinecraftForge.EVENT_BUS.register(CursedRingHandler.class);
+        MinecraftForge.EVENT_BUS.register(VirtueRingHandler.class);
         MinecraftForge.EVENT_BUS.register(LPDeathPrevention.class);
+        MinecraftForge.EVENT_BUS.register(AuraCapabilityProvider.class);
 
         if (ModList.get().isLoaded("irons_spellbooks")) {
             MinecraftForge.EVENT_BUS.register(new IronsCooldownHandler());
@@ -69,6 +73,7 @@ public class ArsNSpells {
     private void registerCaps(RegisterCapabilitiesEvent event) {
         event.register(AffinityData.class);
         event.register(CooldownData.class);
+        event.register(IAuraCapability.class);
     }
 
     private void onAttachCapabilities(AttachCapabilitiesEvent<Entity> event) {

--- a/src/main/java/com/otectus/arsnspells/aura/AuraCapability.java
+++ b/src/main/java/com/otectus/arsnspells/aura/AuraCapability.java
@@ -1,0 +1,88 @@
+package com.otectus.arsnspells.aura;
+
+import com.otectus.arsnspells.config.AnsConfig;
+import net.minecraft.nbt.CompoundTag;
+
+/**
+ * Implementation of aura resource storage.
+ * Aura regenerates passively and is consumed when casting spells with
+ * the Ring of Seven Virtues equipped.
+ */
+public class AuraCapability implements IAuraCapability {
+    private int aura;
+    private int maxAura;
+    private float regenAccumulator = 0f;
+
+    public AuraCapability() {
+        this.maxAura = AnsConfig.AURA_MAX_DEFAULT.get();
+        this.aura = this.maxAura;
+    }
+
+    @Override
+    public int getAura() {
+        return aura;
+    }
+
+    @Override
+    public int getMaxAura() {
+        return maxAura;
+    }
+
+    @Override
+    public void setAura(int amount) {
+        this.aura = Math.max(0, Math.min(amount, maxAura));
+    }
+
+    @Override
+    public void setMaxAura(int amount) {
+        this.maxAura = Math.max(1, amount);
+        if (this.aura > this.maxAura) {
+            this.aura = this.maxAura;
+        }
+    }
+
+    @Override
+    public boolean consumeAura(int amount) {
+        if (amount <= 0) {
+            return true;
+        }
+        if (this.aura < amount) {
+            return false;
+        }
+        this.aura -= amount;
+        return true;
+    }
+
+    @Override
+    public void regenTick() {
+        if (this.aura >= this.maxAura) {
+            this.regenAccumulator = 0f;
+            return;
+        }
+        float regenRate = AnsConfig.AURA_REGEN_RATE.get().floatValue();
+        this.regenAccumulator += regenRate;
+        if (this.regenAccumulator >= 1.0f) {
+            int regen = (int) this.regenAccumulator;
+            this.aura = Math.min(this.maxAura, this.aura + regen);
+            this.regenAccumulator -= regen;
+        }
+    }
+
+    @Override
+    public void saveNBTData(CompoundTag tag) {
+        tag.putInt("aura", this.aura);
+        tag.putInt("maxAura", this.maxAura);
+    }
+
+    @Override
+    public void loadNBTData(CompoundTag tag) {
+        this.aura = tag.getInt("aura");
+        this.maxAura = tag.getInt("maxAura");
+        if (this.maxAura <= 0) {
+            this.maxAura = AnsConfig.AURA_MAX_DEFAULT.get();
+        }
+        if (this.aura > this.maxAura) {
+            this.aura = this.maxAura;
+        }
+    }
+}

--- a/src/main/java/com/otectus/arsnspells/aura/AuraCapabilityProvider.java
+++ b/src/main/java/com/otectus/arsnspells/aura/AuraCapabilityProvider.java
@@ -1,0 +1,90 @@
+package com.otectus.arsnspells.aura;
+
+import net.minecraft.core.Direction;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.CapabilityManager;
+import net.minecraftforge.common.capabilities.CapabilityToken;
+import net.minecraftforge.common.capabilities.ICapabilitySerializable;
+import net.minecraftforge.common.util.LazyOptional;
+import net.minecraftforge.event.AttachCapabilitiesEvent;
+import net.minecraftforge.event.entity.player.PlayerEvent;
+import net.minecraftforge.event.TickEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Forge capability provider for attaching aura data to players.
+ * Handles capability attachment, serialization, and player clone (death/dimension change).
+ */
+@Mod.EventBusSubscriber(modid = "ars_n_spells")
+public class AuraCapabilityProvider implements ICapabilitySerializable<CompoundTag> {
+    public static final ResourceLocation IDENTIFIER = new ResourceLocation("ars_n_spells", "aura");
+    public static final Capability<IAuraCapability> AURA_CAP = CapabilityManager.get(new CapabilityToken<>() {});
+
+    private final AuraCapability backend = new AuraCapability();
+    private final LazyOptional<IAuraCapability> optional = LazyOptional.of(() -> backend);
+
+    @Override
+    public @NotNull <T> LazyOptional<T> getCapability(@NotNull Capability<T> cap, @Nullable Direction side) {
+        if (cap == AURA_CAP) {
+            return optional.cast();
+        }
+        return LazyOptional.empty();
+    }
+
+    @Override
+    public CompoundTag serializeNBT() {
+        CompoundTag tag = new CompoundTag();
+        backend.saveNBTData(tag);
+        return tag;
+    }
+
+    @Override
+    public void deserializeNBT(CompoundTag tag) {
+        backend.loadNBTData(tag);
+    }
+
+    public void invalidate() {
+        optional.invalidate();
+    }
+
+    // --- Event Handlers ---
+
+    @SubscribeEvent
+    public static void onAttachCapabilities(AttachCapabilitiesEvent<Entity> event) {
+        if (event.getObject() instanceof Player) {
+            event.addCapability(IDENTIFIER, new AuraCapabilityProvider());
+        }
+    }
+
+    @SubscribeEvent
+    public static void onPlayerClone(PlayerEvent.Clone event) {
+        // Copy aura data on death/dimension change
+        event.getOriginal().reviveCaps();
+        event.getOriginal().getCapability(AURA_CAP).ifPresent(oldAura -> {
+            event.getEntity().getCapability(AURA_CAP).ifPresent(newAura -> {
+                CompoundTag tag = new CompoundTag();
+                oldAura.saveNBTData(tag);
+                newAura.loadNBTData(tag);
+            });
+        });
+        event.getOriginal().invalidateCaps();
+    }
+
+    @SubscribeEvent
+    public static void onPlayerTick(TickEvent.PlayerTickEvent event) {
+        if (event.phase != TickEvent.Phase.END) {
+            return;
+        }
+        if (event.player.level().isClientSide()) {
+            return;
+        }
+        event.player.getCapability(AURA_CAP).ifPresent(IAuraCapability::regenTick);
+    }
+}

--- a/src/main/java/com/otectus/arsnspells/aura/AuraManager.java
+++ b/src/main/java/com/otectus/arsnspells/aura/AuraManager.java
@@ -1,0 +1,100 @@
+package com.otectus.arsnspells.aura;
+
+import com.hollingsworth.arsnouveau.api.spell.AbstractSpellPart;
+import com.otectus.arsnspells.config.AnsConfig;
+import net.minecraft.world.entity.player.Player;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Central utility for aura resource operations.
+ * Provides cost calculation, validation, and consumption for the Virtue Ring aura system.
+ */
+public class AuraManager {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AuraManager.class);
+
+    /**
+     * Calculate aura cost from a mana cost using configurable formula.
+     * Formula: Aura = (ManaCost x BaseMultiplier) x TierMultiplier
+     */
+    public static int calculateAuraCost(int manaCost, AbstractSpellPart spellPart) {
+        double baseMultiplier = AnsConfig.AURA_BASE_MULTIPLIER.get();
+        double baseCost = manaCost * baseMultiplier;
+
+        int tier = spellPart != null ? spellPart.getConfigTier().value : 1;
+        double tierMultiplier;
+        switch (tier) {
+            case 1:
+                tierMultiplier = AnsConfig.AURA_TIER1_MULTIPLIER.get();
+                break;
+            case 2:
+                tierMultiplier = AnsConfig.AURA_TIER2_MULTIPLIER.get();
+                break;
+            case 3:
+                tierMultiplier = AnsConfig.AURA_TIER3_MULTIPLIER.get();
+                break;
+            default:
+                tierMultiplier = 1.0;
+                break;
+        }
+
+        int finalCost = (int) Math.round(baseCost * tierMultiplier);
+        int minimumCost = AnsConfig.AURA_MINIMUM_COST.get();
+        return Math.max(minimumCost, finalCost);
+    }
+
+    /**
+     * Check if a player has enough aura for a given cost.
+     */
+    public static boolean hasEnoughAura(Player player, int cost) {
+        if (player == null || cost <= 0) {
+            return true;
+        }
+        return player.getCapability(AuraCapabilityProvider.AURA_CAP)
+            .map(cap -> cap.getAura() >= cost)
+            .orElse(false);
+    }
+
+    /**
+     * Consume aura from a player. Returns true if successful.
+     */
+    public static boolean consumeAura(Player player, int cost) {
+        if (player == null || cost <= 0) {
+            return true;
+        }
+        return player.getCapability(AuraCapabilityProvider.AURA_CAP)
+            .map(cap -> {
+                boolean success = cap.consumeAura(cost);
+                if (success) {
+                    LOGGER.debug("Consumed {} aura from {} ({} remaining)",
+                        cost, player.getName().getString(), cap.getAura());
+                }
+                return success;
+            })
+            .orElse(false);
+    }
+
+    /**
+     * Get the current aura of a player.
+     */
+    public static int getAura(Player player) {
+        if (player == null) {
+            return 0;
+        }
+        return player.getCapability(AuraCapabilityProvider.AURA_CAP)
+            .map(IAuraCapability::getAura)
+            .orElse(0);
+    }
+
+    /**
+     * Get the max aura of a player.
+     */
+    public static int getMaxAura(Player player) {
+        if (player == null) {
+            return 0;
+        }
+        return player.getCapability(AuraCapabilityProvider.AURA_CAP)
+            .map(IAuraCapability::getMaxAura)
+            .orElse(0);
+    }
+}

--- a/src/main/java/com/otectus/arsnspells/aura/IAuraCapability.java
+++ b/src/main/java/com/otectus/arsnspells/aura/IAuraCapability.java
@@ -1,0 +1,18 @@
+package com.otectus.arsnspells.aura;
+
+import net.minecraft.nbt.CompoundTag;
+
+/**
+ * Capability interface for the aura resource system.
+ * Aura is consumed instead of mana when wearing the Ring of Seven Virtues.
+ */
+public interface IAuraCapability {
+    int getAura();
+    int getMaxAura();
+    void setAura(int amount);
+    void setMaxAura(int amount);
+    boolean consumeAura(int amount);
+    void regenTick();
+    void saveNBTData(CompoundTag tag);
+    void loadNBTData(CompoundTag tag);
+}

--- a/src/main/java/com/otectus/arsnspells/compat/SanctifiedLegacyCompat.java
+++ b/src/main/java/com/otectus/arsnspells/compat/SanctifiedLegacyCompat.java
@@ -66,7 +66,14 @@ public class SanctifiedLegacyCompat {
                 initBloodMagicReflection();
             }
 
-            LOGGER.info("✅ Sanctified Legacy compatibility layer initialized successfully");
+            // Warn if LP_SOURCE_MODE is BLOOD_MAGIC_ONLY but Blood Magic isn't installed
+            LPSourceMode lpMode = getLPSourceMode();
+            if (lpMode == LPSourceMode.BLOOD_MAGIC_ONLY && !isBloodMagicLoaded) {
+                LOGGER.warn("  LP_SOURCE_MODE is BLOOD_MAGIC_ONLY but Blood Magic is not installed!");
+                LOGGER.warn("  Cursed Ring LP costs will ALWAYS fail. Change to BLOOD_MAGIC_PRIORITY or HEALTH_ONLY.");
+            }
+
+            LOGGER.info("Sanctified Legacy compatibility layer initialized successfully");
         } else {
             LOGGER.info("Sanctified Legacy compatibility skipped: covenant_of_the_seven={}, enigmaticlegacy={}",
                 isLoaded, isEnigmaticLegacyLoaded);

--- a/src/main/java/com/otectus/arsnspells/config/AnsConfig.java
+++ b/src/main/java/com/otectus/arsnspells/config/AnsConfig.java
@@ -129,6 +129,23 @@ public class AnsConfig {
     public static final ForgeConfigSpec.DoubleValue IRONS_LP_LEGENDARY_MULTIPLIER;
 
     // ========================================
+    // AURA SYSTEM (Ring of Seven Virtues)
+    // ========================================
+    public static final ForgeConfigSpec.IntValue AURA_MAX_DEFAULT;
+    public static final ForgeConfigSpec.DoubleValue AURA_REGEN_RATE;
+    public static final ForgeConfigSpec.DoubleValue AURA_BASE_MULTIPLIER;
+    public static final ForgeConfigSpec.DoubleValue AURA_TIER1_MULTIPLIER;
+    public static final ForgeConfigSpec.DoubleValue AURA_TIER2_MULTIPLIER;
+    public static final ForgeConfigSpec.DoubleValue AURA_TIER3_MULTIPLIER;
+    public static final ForgeConfigSpec.IntValue AURA_MINIMUM_COST;
+    public static final ForgeConfigSpec.BooleanValue SHOW_AURA_MESSAGES;
+
+    // ========================================
+    // SCROLL COST SYSTEM
+    // ========================================
+    public static final ForgeConfigSpec.ConfigValue<String> SCROLL_COST_MODE;
+
+    // ========================================
     // PERFORMANCE TUNING
     // ========================================
     public static final ForgeConfigSpec.IntValue MANA_SYNC_INTERVAL;
@@ -493,12 +510,11 @@ public class AnsConfig {
         LP_SOURCE_MODE = BUILDER
             .comment(
                 "Where to consume LP from when wearing the Cursed Ring:",
-                "  BLOOD_MAGIC_ONLY - Only use Blood Magic Soul Network (authentic behavior)",
-                "  BLOOD_MAGIC_PRIORITY - Use Blood Magic if available, fall back to health",
-                "  HEALTH_ONLY - Always use player health (100 LP = 10 health = 5 hearts)",
-                "Default: BLOOD_MAGIC_ONLY - Requires Blood Magic for Cursed Ring to function"
+                "  BLOOD_MAGIC_PRIORITY - Use Blood Magic if available, fall back to health (DEFAULT)",
+                "  BLOOD_MAGIC_ONLY - Only use Blood Magic Soul Network (fails if Blood Magic not installed)",
+                "  HEALTH_ONLY - Always use player health (100 LP = 10 health = 5 hearts)"
             )
-            .define("lp_source_mode", "BLOOD_MAGIC_ONLY");
+            .define("lp_source_mode", "BLOOD_MAGIC_PRIORITY");
 
         DEATH_ON_INSUFFICIENT_LP = BUILDER
             .comment(
@@ -602,6 +618,69 @@ public class AnsConfig {
             .comment("LP multiplier for LEGENDARY rarity spells")
             .defineInRange("irons_lp_legendary_multiplier", 5.0, 0.1, 100.0);
         
+        BUILDER.pop();
+
+        // ========================================
+        // AURA SYSTEM (Ring of Seven Virtues)
+        // ========================================
+        BUILDER.push("Aura System");
+        BUILDER.comment(
+            "Aura resource system for Ring of Seven Virtues.",
+            "When wearing the Virtue Ring, spell mana costs are replaced with aura costs.",
+            "Aura regenerates passively over time."
+        );
+
+        AURA_MAX_DEFAULT = BUILDER
+            .comment("Default maximum aura pool")
+            .defineInRange("aura_max_default", 1000, 100, 100000);
+
+        AURA_REGEN_RATE = BUILDER
+            .comment("Aura regenerated per tick (20 ticks = 1 second). 0.5 = 10 aura/sec")
+            .defineInRange("aura_regen_rate", 0.5, 0.0, 100.0);
+
+        AURA_BASE_MULTIPLIER = BUILDER
+            .comment("Base conversion from mana cost to aura cost (mana x this = base aura)")
+            .defineInRange("aura_base_multiplier", 1.0, 0.1, 100.0);
+
+        AURA_TIER1_MULTIPLIER = BUILDER
+            .comment("Aura cost multiplier for Tier 1 glyphs")
+            .defineInRange("aura_tier1_multiplier", 1.0, 0.1, 10.0);
+
+        AURA_TIER2_MULTIPLIER = BUILDER
+            .comment("Aura cost multiplier for Tier 2 glyphs")
+            .defineInRange("aura_tier2_multiplier", 1.5, 0.1, 10.0);
+
+        AURA_TIER3_MULTIPLIER = BUILDER
+            .comment("Aura cost multiplier for Tier 3 glyphs")
+            .defineInRange("aura_tier3_multiplier", 2.0, 0.1, 10.0);
+
+        AURA_MINIMUM_COST = BUILDER
+            .comment("Minimum aura cost for any spell")
+            .defineInRange("aura_minimum_cost", 5, 1, 10000);
+
+        SHOW_AURA_MESSAGES = BUILDER
+            .comment("Show aura cost messages in action bar when casting spells")
+            .define("show_aura_messages", true);
+
+        BUILDER.pop();
+
+        // ========================================
+        // SCROLL COST SYSTEM
+        // ========================================
+        BUILDER.push("Scroll Cost System");
+        BUILDER.comment(
+            "Controls resource costs when casting Iron's Spellbooks spells from scrolls."
+        );
+
+        SCROLL_COST_MODE = BUILDER
+            .comment(
+                "Cost mode for Iron's Spellbooks scroll usage:",
+                "  full - Scrolls consume mana and LP just like normal casting",
+                "  lp_only - Scrolls are free of mana cost but still consume LP if Cursed Ring equipped",
+                "  free - Scrolls have no resource cost (LP from Cursed Ring still applies)"
+            )
+            .define("scroll_cost_mode", "full");
+
         BUILDER.pop();
 
         // ========================================

--- a/src/main/java/com/otectus/arsnspells/events/CurioDiscountHandler.java
+++ b/src/main/java/com/otectus/arsnspells/events/CurioDiscountHandler.java
@@ -82,32 +82,23 @@ public class CurioDiscountHandler {
      */
     private static double calculateDiscountMultiplier(Player player, SpellCostCalcEvent event) {
         double multiplier = 1.0;
-        
-        // Check for Ring of Virtue discount
-        boolean hasVirtue = SanctifiedLegacyCompat.hasVirtueRing(player);
-        if (hasVirtue) {
-            double virtueDiscount = AnsConfig.VIRTUE_RING_DISCOUNT.get();
-            multiplier *= (1.0 - virtueDiscount);
-            
-            logDebug("Ring of Virtue discount applied: {:.1f}%", virtueDiscount * 100);
-        }
-        
+
+        // Virtue Ring no longer provides a mana discount — it converts mana to aura via
+        // VirtueRingHandler. If the Virtue Ring is active, the cost has already been zeroed
+        // by VirtueRingHandler at HIGHEST priority, so this handler won't be reached (cost <= 0).
+        // Only Blasphemy discounts apply here (for non-ring or Cursed Ring users).
+
         // Check for Blasphemy discount
         String spellSchool = determineSpellSchool(event);
         BlasphemyDiscountResult blasphemyResult = calculateBlasphemyDiscount(player, spellSchool);
-        
+
         if (blasphemyResult.hasBlasphemy) {
-            if (AnsConfig.ALLOW_DISCOUNT_STACKING.get() || !hasVirtue) {
-                // Apply Blasphemy discount (stacking multiplicatively if allowed)
-                multiplier *= (1.0 - blasphemyResult.totalDiscount);
-                
-                logDebug("Blasphemy discount applied: {:.1f}% (school: {}, matching: {})",
-                    blasphemyResult.totalDiscount * 100, spellSchool, blasphemyResult.isMatching);
-            } else {
-                logDebug("Blasphemy discount skipped (stacking disabled and Virtue Ring active)");
-            }
+            multiplier *= (1.0 - blasphemyResult.totalDiscount);
+
+            logDebug("Blasphemy discount applied: {:.1f}% (school: {}, matching: {})",
+                blasphemyResult.totalDiscount * 100, spellSchool, blasphemyResult.isMatching);
         }
-        
+
         return multiplier;
     }
     

--- a/src/main/java/com/otectus/arsnspells/events/IronsLPHandler.java
+++ b/src/main/java/com/otectus/arsnspells/events/IronsLPHandler.java
@@ -189,6 +189,16 @@ public class IronsLPHandler {
     }
 
     /**
+     * Store a pending LP cost for scroll-based casting.
+     * Called by MixinScrollItem to integrate with the LP tracking system.
+     */
+    public static void storePendingScrollLP(Player player, int lpCost, int manaCost) {
+        if (player != null) {
+            pendingCosts.put(player.getUUID(), new PendingIronsLP(lpCost, manaCost, System.currentTimeMillis()));
+        }
+    }
+
+    /**
      * Container for pending Iron's spell LP costs.
      */
     private static class PendingIronsLP {

--- a/src/main/java/com/otectus/arsnspells/events/VirtueRingHandler.java
+++ b/src/main/java/com/otectus/arsnspells/events/VirtueRingHandler.java
@@ -1,0 +1,208 @@
+package com.otectus.arsnspells.events;
+
+import com.hollingsworth.arsnouveau.api.event.SpellCostCalcEvent;
+import com.hollingsworth.arsnouveau.api.event.SpellResolveEvent;
+import com.hollingsworth.arsnouveau.api.spell.AbstractSpellPart;
+import com.otectus.arsnspells.aura.AuraManager;
+import com.otectus.arsnspells.compat.SanctifiedLegacyCompat;
+import com.otectus.arsnspells.config.AnsConfig;
+import com.otectus.arsnspells.util.CasterContext;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraftforge.eventbus.api.EventPriority;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Handles Virtue Ring aura consumption for Ars Nouveau spells.
+ * When the Ring of Seven Virtues is equipped, mana costs are replaced with aura costs.
+ * Mirrors the architecture of CursedRingHandler for LP.
+ */
+@Mod.EventBusSubscriber(modid = "ars_n_spells")
+public class VirtueRingHandler {
+    private static final Logger LOGGER = LoggerFactory.getLogger(VirtueRingHandler.class);
+
+    private static final Map<UUID, PendingAuraCost> pendingCosts = new HashMap<>();
+
+    /**
+     * Calculate aura cost and replace mana cost when Virtue Ring is equipped.
+     * Runs at HIGHEST priority to ensure it processes before other cost modifiers.
+     */
+    @SubscribeEvent(priority = EventPriority.HIGHEST)
+    public static void onSpellCostCalc(SpellCostCalcEvent event) {
+        if (!SanctifiedLegacyCompat.isAvailable()) {
+            return;
+        }
+
+        LivingEntity caster = event.context != null ? event.context.getUnwrappedCaster() : null;
+        if (!(caster instanceof Player player)) {
+            return;
+        }
+
+        if (player.level().isClientSide()) {
+            return;
+        }
+
+        if (!SanctifiedLegacyCompat.isWearingVirtueRing(player)) {
+            return;
+        }
+
+        int manaCost = event.currentCost;
+        if (manaCost <= 0) {
+            return;
+        }
+
+        LOGGER.debug("Virtue Ring detected on {} - Spell will use Aura instead of mana",
+            player.getName().getString());
+
+        // Get spell part for tier calculation
+        AbstractSpellPart spellPart = CasterContext.getSpell()
+            .filter(spell -> spell.recipe != null && !spell.recipe.isEmpty())
+            .map(spell -> spell.recipe.get(0))
+            .orElse(null);
+
+        // Calculate aura cost
+        int auraCost = AuraManager.calculateAuraCost(manaCost, spellPart);
+
+        // Apply Blasphemy discount to aura cost
+        String spellSchool = SanctifiedLegacyCompat.determineSpellSchool(spellPart);
+        double blasphemyMultiplier = SanctifiedLegacyCompat.getBlasphemyMultiplier(player, spellSchool);
+        if (blasphemyMultiplier < 1.0) {
+            int originalCost = auraCost;
+            auraCost = (int) Math.max(AnsConfig.AURA_MINIMUM_COST.get(),
+                Math.round(auraCost * blasphemyMultiplier));
+            LOGGER.debug("Blasphemy discount applied to aura: {} -> {}", originalCost, auraCost);
+        }
+
+        LOGGER.debug("Spell will cost {} aura (base mana: {})", auraCost, manaCost);
+
+        // Store the aura cost for consumption on spell resolve
+        pendingCosts.put(player.getUUID(), new PendingAuraCost(auraCost, System.currentTimeMillis()));
+
+        // Set mana cost to 0 so Ars Nouveau doesn't consume mana
+        event.currentCost = 0;
+    }
+
+    /**
+     * Get the pending aura cost for a player. Returns -1 if none.
+     */
+    public static int getPendingAuraCost(Player player) {
+        if (player == null) {
+            return -1;
+        }
+        PendingAuraCost pending = pendingCosts.get(player.getUUID());
+        if (pending == null) {
+            return -1;
+        }
+        if (System.currentTimeMillis() - pending.timestamp > 5000) {
+            pendingCosts.remove(player.getUUID());
+            return -1;
+        }
+        return pending.auraCost;
+    }
+
+    /**
+     * Clear any pending aura cost for the player.
+     */
+    public static void clearPendingAuraCost(Player player) {
+        if (player != null) {
+            pendingCosts.remove(player.getUUID());
+        }
+    }
+
+    /**
+     * Consume aura when the spell resolves.
+     */
+    @SubscribeEvent(priority = EventPriority.HIGHEST)
+    public static void onSpellResolve(SpellResolveEvent.Pre event) {
+        if (!SanctifiedLegacyCompat.isAvailable()) {
+            return;
+        }
+
+        if (event.context == null) {
+            return;
+        }
+
+        LivingEntity caster = event.context.getUnwrappedCaster();
+        if (!(caster instanceof ServerPlayer player)) {
+            return;
+        }
+
+        PendingAuraCost pending = pendingCosts.get(player.getUUID());
+        if (pending == null) {
+            return;
+        }
+
+        if (System.currentTimeMillis() - pending.timestamp > 5000) {
+            LOGGER.warn("Pending aura cost expired for {}", player.getName().getString());
+            pendingCosts.remove(player.getUUID());
+            return;
+        }
+
+        if (pending.consumed) {
+            return;
+        }
+
+        LOGGER.debug("Consuming {} aura from {}", pending.auraCost, player.getName().getString());
+
+        boolean success = AuraManager.consumeAura(player, pending.auraCost);
+
+        if (!success) {
+            LOGGER.warn("Insufficient aura - cancelling spell");
+            event.setCanceled(true);
+            pendingCosts.remove(player.getUUID());
+
+            if (AnsConfig.SHOW_AURA_MESSAGES.get()) {
+                int currentAura = AuraManager.getAura(player);
+                player.displayClientMessage(
+                    Component.literal("\u00a7bInsufficient Aura: Need " + pending.auraCost
+                        + ", have " + currentAura),
+                    true
+                );
+            }
+        } else {
+            pending.consumed = true;
+
+            if (AnsConfig.SHOW_AURA_MESSAGES.get()) {
+                int remaining = AuraManager.getAura(player);
+                player.displayClientMessage(
+                    Component.literal("\u00a7bConsumed " + pending.auraCost + " Aura (" + remaining + " remaining)"),
+                    true
+                );
+            }
+        }
+    }
+
+    /**
+     * Clean up expired pending costs.
+     */
+    @SubscribeEvent
+    public static void onPlayerTick(net.minecraftforge.event.TickEvent.PlayerTickEvent event) {
+        if (event.phase != net.minecraftforge.event.TickEvent.Phase.END) {
+            return;
+        }
+        if (event.player.tickCount % 100 == 0) {
+            long now = System.currentTimeMillis();
+            pendingCosts.entrySet().removeIf(entry -> now - entry.getValue().timestamp > 5000);
+        }
+    }
+
+    private static class PendingAuraCost {
+        final int auraCost;
+        final long timestamp;
+        boolean consumed = false;
+
+        PendingAuraCost(int auraCost, long timestamp) {
+            this.auraCost = auraCost;
+            this.timestamp = timestamp;
+        }
+    }
+}

--- a/src/main/java/com/otectus/arsnspells/mixin/ArsNSpellsMixinPlugin.java
+++ b/src/main/java/com/otectus/arsnspells/mixin/ArsNSpellsMixinPlugin.java
@@ -30,7 +30,8 @@ public class ArsNSpellsMixinPlugin implements IMixinConfigPlugin {
         if (mixinClassName.endsWith("MixinIronsSpellDamage")
             || mixinClassName.endsWith("MixinIronsManaBarOverlay")
             || mixinClassName.endsWith("MixinIronsMagicDataMana")
-            || mixinClassName.endsWith("MixinSpellStatsPotency")) {
+            || mixinClassName.endsWith("MixinSpellStatsPotency")
+            || mixinClassName.endsWith("MixinScrollItem")) {
             return ironsPresent;
         }
         return true;

--- a/src/main/java/com/otectus/arsnspells/mixin/ars/MixinArsManaRegen.java
+++ b/src/main/java/com/otectus/arsnspells/mixin/ars/MixinArsManaRegen.java
@@ -1,30 +1,32 @@
-package com.otectus.arsnspells.mixin.ars;
-
-import com.otectus.arsnspells.bridge.BridgeManager;
-import com.hollingsworth.arsnouveau.common.capability.ManaCap;
-import net.minecraft.world.entity.LivingEntity;
-import net.minecraft.world.entity.player.Player;
-import org.spongepowered.asm.mixin.Final;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-
-@Mixin(value = ManaCap.class, remap = false)
-public abstract class MixinArsManaRegen {
-
-    @Shadow @Final private LivingEntity livingEntity;
-
-    // Prevents Ars native regeneration if the bridge is using Iron's Spells mana.
-    // This ensures only one mana pool manages recovery.
-    @Inject(method = "tick", at = @At("HEAD"), cancellable = true)
-    private void arsnspells$suppressNativeRegen(CallbackInfo ci) {
-        if (this.livingEntity instanceof Player) {
-            if (BridgeManager.getBridge().getBridgeType().equals("IRONS_SPELLS")) {
-                // Cancellation logic: Let Iron's handles the mana tick.
-                ci.cancel();
-            }
-        }
-    }
+package com.otectus.arsnspells.mixin.ars;
+
+import com.otectus.arsnspells.bridge.BridgeManager;
+import com.otectus.arsnspells.config.ManaUnificationMode;
+import com.hollingsworth.arsnouveau.common.capability.ManaCap;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(value = ManaCap.class, remap = false)
+public abstract class MixinArsManaRegen {
+
+    @Shadow @Final private LivingEntity livingEntity;
+
+    // Prevents Ars native regeneration only in ISS_PRIMARY mode where Iron's is
+    // the sole mana source. In HYBRID mode, Ars tick must run to properly
+    // initialize and maintain its native max mana value (150).
+    @Inject(method = "tick", at = @At("HEAD"), cancellable = true)
+    private void arsnspells$suppressNativeRegen(CallbackInfo ci) {
+        if (this.livingEntity instanceof Player) {
+            ManaUnificationMode mode = BridgeManager.getCurrentMode();
+            if (mode != null && mode.isIssPrimary()) {
+                ci.cancel();
+            }
+        }
+    }
 }

--- a/src/main/java/com/otectus/arsnspells/mixin/ars/MixinManaCapability.java
+++ b/src/main/java/com/otectus/arsnspells/mixin/ars/MixinManaCapability.java
@@ -8,6 +8,7 @@ import net.minecraft.world.entity.player.Player;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
@@ -15,11 +16,19 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(value = ManaCap.class, remap = false)
 public abstract class MixinManaCapability {
-    
+
     // Shadowing the verified field name: livingEntity
     @Shadow @Final private LivingEntity livingEntity;
     @Shadow private double mana;
     @Shadow private int maxMana;
+
+    /**
+     * Tracks the Ars Nouveau native max mana value in HYBRID mode.
+     * This prevents Iron's default (200) from leaking into the displayed max.
+     * Captured when Ars calls setMaxMana() during capability initialization.
+     */
+    @Unique
+    private int arsnspells$arsNativeMaxMana = -1;
 
     @Inject(method = "getCurrentMana", at = @At("HEAD"), cancellable = true)
     private void arsnspells$getCurrentMana(CallbackInfoReturnable<Double> cir) {
@@ -29,10 +38,12 @@ public abstract class MixinManaCapability {
             }
             double current = (double) BridgeManager.getBridge().getMana(player);
             ManaUnificationMode mode = BridgeManager.getCurrentMode();
-            // In HYBRID mode, cap current mana at Ars native max so the HUD
-            // doesn't show mana exceeding the displayed max value
+            // In HYBRID mode, cap current mana at the Ars native max so the HUD
+            // doesn't show mana exceeding the displayed max value.
+            // Use the captured native max if available, otherwise fall back to shadow field.
             if (mode != null && mode.isHybrid()) {
-                current = Math.min(current, this.maxMana);
+                int cap = arsnspells$arsNativeMaxMana > 0 ? arsnspells$arsNativeMaxMana : this.maxMana;
+                current = Math.min(current, cap);
             }
             cir.setReturnValue(current);
         }
@@ -45,10 +56,12 @@ public abstract class MixinManaCapability {
                 return;
             }
             ManaUnificationMode mode = BridgeManager.getCurrentMode();
-            // In HYBRID mode, let Ars report its own native max mana so the
-            // displayed value matches Ars's base pool (150) rather than Iron's (200).
-            // The bridge handles actual mana sync between the two systems.
+            // In HYBRID mode, report the captured Ars native max mana (typically 150)
+            // rather than Iron's value (200). If not yet captured, let Ars report natively.
             if (mode != null && mode.isHybrid()) {
+                if (arsnspells$arsNativeMaxMana > 0) {
+                    cir.setReturnValue(arsnspells$arsNativeMaxMana);
+                }
                 return;
             }
             cir.setReturnValue((int) BridgeManager.getBridge().getMaxMana(player));
@@ -113,9 +126,13 @@ public abstract class MixinManaCapability {
             return;
         }
         ManaUnificationMode mode = BridgeManager.getCurrentMode();
+        // In HYBRID mode, capture the Ars native max value but let Ars set it normally.
+        // This prevents Iron's default (200) from overriding Ars's native max (150).
+        if (mode != null && mode.isHybrid()) {
+            arsnspells$arsNativeMaxMana = amount;
+            return; // Let Ars set its own maxMana natively
+        }
         // Only redirect in ISS_PRIMARY mode where Iron's is the sole source of truth.
-        // In HYBRID mode, Ars manages its own max mana natively to prevent
-        // Iron's default (200) from overriding Ars's native max (150).
         if (mode == null || !mode.isIssPrimary()) {
             return;
         }

--- a/src/main/java/com/otectus/arsnspells/mixin/ars/MixinSpellResolverContext.java
+++ b/src/main/java/com/otectus/arsnspells/mixin/ars/MixinSpellResolverContext.java
@@ -1,27 +1,35 @@
-package com.otectus.arsnspells.mixin.ars;
-
-import com.hollingsworth.arsnouveau.api.spell.SpellContext;
-import com.hollingsworth.arsnouveau.api.spell.SpellResolver;
-import com.otectus.arsnspells.util.CasterContext;
-import net.minecraft.world.entity.player.Player;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-
-@Mixin(value = SpellResolver.class, remap = false)
-public class MixinSpellResolverContext {
-    // Added require = 0 for stability. This mixin captures casting context for scaling logic.
-    @Inject(method = "resolve", at = @At("HEAD"), require = 0)
-    private void arsnspells$captureContext(SpellContext context, CallbackInfoReturnable<Boolean> cir) {
-        if (context.getCaster() instanceof Player player) {
-            SpellResolver resolver = (SpellResolver) (Object) this;
-            CasterContext.set(player, resolver.spell);
-        }
-    }
-
-    @Inject(method = "resolve", at = @At("RETURN"), require = 0)
-    private void arsnspells$clearContext(SpellContext context, CallbackInfoReturnable<Boolean> cir) {
-        CasterContext.clear();
-    }
+package com.otectus.arsnspells.mixin.ars;
+
+import com.hollingsworth.arsnouveau.api.spell.SpellContext;
+import com.hollingsworth.arsnouveau.api.spell.SpellResolver;
+import com.otectus.arsnspells.util.CasterContext;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+/**
+ * Captures the spell context for use by cost calculation handlers.
+ * Injects into canCast() which is called by all cast paths and
+ * triggers SpellCostCalcEvent via getResolveCost() -> enoughMana().
+ */
+@Mixin(value = SpellResolver.class, remap = false)
+public class MixinSpellResolverContext {
+    @Shadow public SpellContext spellContext;
+
+    @Inject(method = "canCast", at = @At("HEAD"))
+    private void arsnspells$captureContext(LivingEntity entity, CallbackInfoReturnable<Boolean> cir) {
+        if (entity instanceof Player player) {
+            SpellResolver resolver = (SpellResolver) (Object) this;
+            CasterContext.set(player, resolver.spell);
+        }
+    }
+
+    @Inject(method = "canCast", at = @At("RETURN"))
+    private void arsnspells$clearContext(LivingEntity entity, CallbackInfoReturnable<Boolean> cir) {
+        CasterContext.clear();
+    }
 }

--- a/src/main/java/com/otectus/arsnspells/mixin/ars/MixinSpellResolverMana.java
+++ b/src/main/java/com/otectus/arsnspells/mixin/ars/MixinSpellResolverMana.java
@@ -24,21 +24,22 @@ public abstract class MixinSpellResolverMana {
 
     @Inject(method = "expendMana", at = @At("HEAD"), cancellable = true)
     private void arsnspells$expendMana(CallbackInfo ci) {
-        // SANCTIFIED LEGACY INTEGRATION: Skip mana consumption ONLY for Cursed Ring
-        // (Cursed Ring consumes health instead of mana via CastingAuthority)
-        // Virtue Ring still uses mana but with a discount applied by CurioDiscountHandler
+        // SANCTIFIED LEGACY INTEGRATION: Skip mana consumption for Cursed Ring and Virtue Ring
+        // - Cursed Ring: LP was consumed in CursedRingHandler.onSpellResolve
+        // - Virtue Ring: Aura was consumed in VirtueRingHandler.onSpellResolve
         if (spellContext != null) {
             LivingEntity caster = spellContext.getUnwrappedCaster();
             if (caster instanceof Player player) {
                 if (SanctifiedLegacyCompat.isAvailable()) {
                     if (SanctifiedLegacyCompat.isWearingCursedRing(player)) {
-                        // LP (health) was already consumed in CastingAuthority pre-cast validation
-                        // Skip mana consumption entirely for Cursed Ring users
                         ci.cancel();
                         return;
                     }
-                    // NOTE: Virtue Ring users continue to mana consumption below
-                    // Their mana cost was already discounted by CurioDiscountHandler
+                    if (SanctifiedLegacyCompat.isWearingVirtueRing(player)) {
+                        // Aura was already consumed by VirtueRingHandler
+                        ci.cancel();
+                        return;
+                    }
                 }
             }
         }

--- a/src/main/java/com/otectus/arsnspells/mixin/irons/MixinScrollItem.java
+++ b/src/main/java/com/otectus/arsnspells/mixin/irons/MixinScrollItem.java
@@ -1,0 +1,144 @@
+package com.otectus.arsnspells.mixin.irons;
+
+import com.otectus.arsnspells.compat.SanctifiedLegacyCompat;
+import com.otectus.arsnspells.config.AnsConfig;
+import com.otectus.arsnspells.events.IronsLPHandler;
+import com.otectus.arsnspells.events.LPDeathPrevention;
+import io.redspace.ironsspellbooks.api.spells.AbstractSpell;
+import io.redspace.ironsspellbooks.api.spells.ISpellContainer;
+import io.redspace.ironsspellbooks.api.spells.SpellData;
+import io.redspace.ironsspellbooks.api.spells.SpellRarity;
+import io.redspace.ironsspellbooks.api.registry.SpellRegistry;
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResultHolder;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+/**
+ * Intercepts Iron's Spellbooks scroll usage to enforce resource costs.
+ * Scrolls normally bypass SpellPreCastEvent/SpellOnCastEvent, so without
+ * this mixin, scrolls would cast for free (no mana, LP, or aura consumed).
+ *
+ * Behavior is controlled by the scroll_cost_mode config:
+ * - "full": Scrolls consume mana and LP like normal casting
+ * - "lp_only": Scrolls are mana-free but LP is still consumed for Cursed Ring
+ * - "free": No resource cost, but LP from Cursed Ring still applies
+ */
+@Mixin(targets = "io.redspace.ironsspellbooks.item.Scroll", remap = false)
+public class MixinScrollItem {
+    private static final Logger LOGGER = LoggerFactory.getLogger(MixinScrollItem.class);
+
+    @Inject(method = "use", at = @At("HEAD"), cancellable = true, require = 0)
+    private void arsnspells$validateScrollCast(Level level, Player player, InteractionHand hand,
+            CallbackInfoReturnable<InteractionResultHolder<ItemStack>> cir) {
+        if (level.isClientSide()) {
+            return;
+        }
+
+        if (player.isCreative()) {
+            return;
+        }
+
+        ItemStack stack = player.getItemInHand(hand);
+
+        // Extract spell data from scroll
+        SpellData spellData = null;
+        try {
+            ISpellContainer container = ISpellContainer.get(stack);
+            if (container != null) {
+                spellData = container.getSpellAtIndex(0);
+            }
+        } catch (Exception e) {
+            LOGGER.debug("Could not read spell data from scroll: {}", e.getMessage());
+            return;
+        }
+
+        if (spellData == null) {
+            return;
+        }
+
+        AbstractSpell spell = spellData.getSpell();
+        int spellLevel = spellData.getLevel();
+        if (spell == null) {
+            return;
+        }
+
+        String scrollMode = AnsConfig.SCROLL_COST_MODE.get().toLowerCase();
+        int manaCost = spell.getManaCost(spellLevel);
+
+        // --- Cursed Ring LP validation (always applies regardless of scroll_cost_mode) ---
+        if (SanctifiedLegacyCompat.isAvailable() && SanctifiedLegacyCompat.isWearingCursedRing(player)) {
+            if (manaCost > 0) {
+                SpellRarity rarity = spell.getRarity(spellLevel);
+                int lpCost = SanctifiedLegacyCompat.calculateIronsLPCost(manaCost, spellLevel, rarity.name());
+
+                LOGGER.debug("Scroll LP validation: spell={}, level={}, lpCost={}",
+                    spell.getSpellId(), spellLevel, lpCost);
+
+                boolean hasEnough = SanctifiedLegacyCompat.hasEnoughLP(player, lpCost);
+                if (!hasEnough) {
+                    if (AnsConfig.DEATH_ON_INSUFFICIENT_LP.get()) {
+                        // Death penalty: allow scroll, mark for death
+                        LPDeathPrevention.markSpellCast(player);
+                        // LP consumption will happen below or in post-cast
+                    } else {
+                        // Safe mode: cancel scroll use
+                        LOGGER.warn("Insufficient LP for scroll - cancelling");
+                        cir.setReturnValue(InteractionResultHolder.fail(stack));
+
+                        SanctifiedLegacyCompat.applySilentHealthLoss(player, 2.0f);
+
+                        if (AnsConfig.SHOW_LP_COST_MESSAGES.get()) {
+                            player.displayClientMessage(
+                                Component.literal(ChatFormatting.RED + "Insufficient LP - Scroll Cancelled"),
+                                true);
+                        }
+                        return;
+                    }
+                }
+
+                // Mark spell cast for death prevention system
+                LPDeathPrevention.markSpellCast(player);
+
+                // Store pending LP cost for consumption after scroll cast
+                IronsLPHandler.storePendingScrollLP(player, lpCost, manaCost);
+
+                if (AnsConfig.SHOW_LP_COST_MESSAGES.get()) {
+                    player.displayClientMessage(
+                        Component.literal(ChatFormatting.GOLD + "Consumed " + lpCost + " LP"),
+                        true);
+                }
+
+                // Consume LP now (before scroll executes)
+                SanctifiedLegacyCompat.consumeLP(player, lpCost);
+
+                // Scroll uses LP instead of mana; allow the scroll to proceed
+                return;
+            }
+        }
+
+        // --- Mana cost validation (based on scroll_cost_mode) ---
+        if ("free".equals(scrollMode) || "lp_only".equals(scrollMode)) {
+            // No mana cost for scrolls in these modes
+            return;
+        }
+
+        // "full" mode: validate mana like a normal spell cast
+        if (manaCost > 0) {
+            boolean canAfford = com.otectus.arsnspells.casting.CastingAuthority.canCastIronsSpell(player, manaCost);
+            if (!canAfford) {
+                cir.setReturnValue(InteractionResultHolder.fail(stack));
+                return;
+            }
+        }
+    }
+}

--- a/src/main/java/com/otectus/arsnspells/mixin/sanctified/MixinSanctifiedAbstractSpell.java
+++ b/src/main/java/com/otectus/arsnspells/mixin/sanctified/MixinSanctifiedAbstractSpell.java
@@ -51,10 +51,12 @@ public abstract class MixinSanctifiedAbstractSpell {
             return;
         }
         
-        LOGGER.info("🔍 Intercepting Sanctified Legacy's LP check for {}", player.getName().getString());
-        
-        // Let Sanctified Legacy's mixin run, but we'll handle the death penalty ourselves
-        // We can't easily prevent their death penalty here, so we'll use a different approach
-        // in the spell cast event
+        LOGGER.debug("Intercepting Sanctified Legacy LP check for {}", player.getName().getString());
+
+        // Our LP system (IronsLPHandler / CursedRingHandler) handles this player's LP costs.
+        // Return true to bypass Sanctified Legacy's native LP check and death penalty.
+        // This prevents the "instant death" bug when scrolls or spells trigger
+        // Sanctified Legacy's handler before our system processes the cost.
+        cir.setReturnValue(true);
     }
 }

--- a/src/main/resources/ars_n_spells.mixins.json
+++ b/src/main/resources/ars_n_spells.mixins.json
@@ -14,13 +14,14 @@
     "ars.MixinArsManaRegen",
     "ars.MixinArsPotionEffects",
     "irons.MixinIronsSpellDamage",
-    "irons.MixinIronsMagicDataMana"
+    "irons.MixinIronsMagicDataMana",
+    "irons.MixinScrollItem"
   ],
   "client": [
     "ars.MixinArsManaHud",
     "irons.MixinIronsManaBarOverlay"
   ],
   "injectors": {
-    "defaultRequire": 0
+    "defaultRequire": 1
   }
 }


### PR DESCRIPTION
Bug 1: Fix pre-cast validation mixin that never injected. The mixin targeted a non-existent resolve() method on SpellResolver with defaultRequire:0 silently suppressing the failure. Retargeted to canCast() (the actual validation gate) and set defaultRequire:1.

Bug 2+3: Add MixinScrollItem to enforce costs on Iron's scroll usage. Scrolls bypass SpellPreCastEvent/SpellOnCastEvent, so without this mixin scrolls cast for free. Adds scroll_cost_mode config (full/ lp_only/free). Updated MixinSanctifiedAbstractSpell to bypass native death penalty when our LP system is active.

Bug 4: Change LP_SOURCE_MODE default from BLOOD_MAGIC_ONLY to BLOOD_MAGIC_PRIORITY so health-based LP works without Blood Magic. Added startup warning when BM-only mode is set without BM installed.

Bug 5: Implement aura resource system for Ring of Seven Virtues. New capability (IAuraCapability/AuraCapability/AuraCapabilityProvider), AuraManager utility, and VirtueRingHandler that mirrors CursedRingHandler architecture. Virtue Ring now converts mana to aura costs instead of giving a flat discount.

Bug 6: Fix hybrid mode showing 200 mana instead of 150. Added @Unique field in MixinManaCapability to track Ars native max separately. Changed MixinArsManaRegen to only suppress Ars regen in ISS_PRIMARY, not HYBRID mode.